### PR TITLE
Generate html from template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 .sass-cache/
 node_modules/
+
+# build artifacts
+dist/

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -69,7 +69,7 @@ var gulp = require('gulp'),
         }
     };
 
-gulp.task('serve', ['sass'], function () {
+gulp.task('serve', ['sass', 'webpack'], function () {
 
     browserSync.init({
         server: config.browserSync.server,
@@ -96,7 +96,7 @@ gulp.task('sass', function () {
         .pipe(browserSync.stream());
 });
 
-gulp.task('webpack', function () {
+gulp.task('webpack', function (callback) {
     var wConfig = require(config.js.webpackConfig)(config.js.webpackParams),
         bundler = webpack(wConfig);
 
@@ -105,6 +105,9 @@ gulp.task('webpack', function () {
         gulpUtil.log("[webpack]", stats.toString({
             // output options
         }));
+
+        // notify gulp source is compiled
+        callback();
 
         if (config.js.watch) {
             browserSync.reload();

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.9.0",
     "browser-sync": "^2.13.0",
     "css-loader": "^0.23.1",
     "gm": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-webpack": "^1.5.0",
     "gulp.spritesmith": "^6.2.1",
     "html-loader": "^0.4.3",
+    "html-webpack-plugin": "^2.21.0",
     "minimist": "^1.2.0",
     "node-sass": "^3.7.0",
     "sass-loader": "^3.2.0",

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title></title>
-    <link rel="stylesheet" href="css/style.css"/>
-    <script src="js/bundle.js"></script>
+    <link rel="stylesheet" href="css/style.css"/>    
 </head>
 <body>
 <div>Start page</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack'),
-    UglifyJsPlugin = require('uglify-js');
+    UglifyJsPlugin = require('uglify-js'),
+    HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = function (params) {
 
@@ -19,6 +20,7 @@ module.exports = function (params) {
         plugins: params.RELEASE ?
             [
                 new webpack.ProvidePlugin(params.globalModules),
+                new HtmlWebpackPlugin({template: 'src/index.html', filename: '../index.html'}),
                 new webpack.optimize.UglifyJsPlugin({
                     minimize: true
                 }),
@@ -26,7 +28,8 @@ module.exports = function (params) {
             ]
                                 :
             [
-                new webpack.ProvidePlugin(params.globalModules)
+                new webpack.ProvidePlugin(params.globalModules),
+                new HtmlWebpackPlugin({template: 'src/index.html', filename: '../index.html'})
             ],
         resolve: {
             modulesDirectories: params.input


### PR DESCRIPTION
# Intent

Keeping `index.html` in `dist` directory prevented it from being added to ignored dirs. 
It can be solved by moving `index.html` to `src` and using [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) to generate `index.html` using one in sources as template. 
Such a generation has additional benefit of automatically including all bundles generated by webpack regardless of names of those bundles.
## Notes on gulpfile changes

Sometimes it happened that server was started before webpack generated html and js bundles. Dependency on `webpack` task was added to `serve` task. Also as webpack did not use gulp streaming adding of `callback` was necessary to let `gulp` know when webpack task finishes.
